### PR TITLE
Create setup for building libguestfs appliance 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.tar.xz
+output

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM fedora:33
+
+env LIBGUESTFS_BACKEND direct
+
+RUN dnf update -y && dnf install --setopt=install_weak_deps=False -y \
+    libguestfs  \
+    libguestfs-devel \
+    && dnf clean all
+
+RUN mkdir -p /output \
+    && cd /output \
+    && libguestfs-make-fixed-appliance --xz

--- a/create-libguestfs-appliance.sh
+++ b/create-libguestfs-appliance.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -xe
+
+IMAGE=${IMAGE:-libguestfs-appliance}
+CONT_NAME=extract-libguestfs-appliance
+# Select an available container runtime
+if [ -z ${RUNTIME} ]; then
+    if docker ps >/dev/null; then
+        RUNTIME=docker
+        echo "selecting docker as container runtime"
+    elif podman ps >/dev/null; then
+        RUNTIME=podman
+        echo "selecting podman as container runtime"
+    else
+        echo "no working container runtime found. Neither docker nor podman seems to work."
+        exit 1
+    fi
+fi
+
+
+${RUNTIME} build --rm -t ${IMAGE}  .
+${RUNTIME} create --name ${CONT_NAME} ${IMAGE} sh
+${RUNTIME} cp ${CONT_NAME}:/output .
+${RUNTIME} rm ${CONT_NAME}


### PR DESCRIPTION
This setup builds the libguestfs appliance that can be later used on other platforms. This is especially useful to be integrated with container images built using bazel as bazel doesn't run post-installation scripts.
