### PR TITLE
Set version on the libguestfs-appliance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,8 @@ RUN dnf update -y && dnf install --setopt=install_weak_deps=False -y \
 
 RUN mkdir -p /output \
     && cd /output \
-    && libguestfs-make-fixed-appliance --xz
+    && libguestfs-make-fixed-appliance --xz \
+    && KERNEL_VERSION=$(rpm -qa  kernel-core | sed 's/kernel-core-\(.*\)\.fc.*/\1/') \
+    && LIBGUESTFS_VERSION=$(libguestfs-make-fixed-appliance --version | sed 's/libguestfs-make-fixed-appliance //') \
+    && source /etc/os-release \
+    && mv appliance-${LIBGUESTFS_VERSION}.tar.xz appliance-${LIBGUESTFS_VERSION}-linux-${KERNEL_VERSION}-${ID}${VERSION_ID}.tar.xz


### PR DESCRIPTION
The published appliance version tarball will be in the form:
   `appliance-<libguestfs version>-linux-<kernel version>-<base-os>.tar.xz`

Signed-off-by: Alice Frosi <afrosi@redhat.com>