### PR TITLE
Use the same fedora version as the images used by kubevirt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:33
+FROM fedora:32
 
 env LIBGUESTFS_BACKEND direct
 


### PR DESCRIPTION
Signed-off-by: Alice Frosi <afrosi@redhat.com>