### PR TITLE
create appliance with root in qcow2 format

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,8 @@
+# Expose libguestfs appliance files for bazel and to be consumed as http-archive().
+# The files listed here will be accessible by name.
+
+exports_files(["root",
+               "README.fixed",
+               "kernel",
+               "initrd",
+])


### PR DESCRIPTION
Container tools do not always support sparse files. Therefore, the
sparse files are preallocated and require the full size space. In order
to reduce the amount of space, we can transform the default root of the
appliance in raw format into a qcow2 image.

Signed-off-by: Alice Frosi <afrosi@redhat.com>