### PR TITLE
Switch to CentOS Stream 9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,20 @@
 FROM quay.io/centos/centos:stream8
 
-env LIBGUESTFS_BACKEND direct
+ENV LIBGUESTFS_BACKEND direct
 
 # Install centos-release-advanced-virtualization to get the Advanced Virtualization package version
-RUN yum update -y && yum install -y centos-release-advanced-virtualization && yum update \
-    && yum install --setopt=install_weak_deps=False -y \
-    libguestfs  \
-    libguestfs-devel \
-    && yum clean all
+RUN dnf update -y && \
+    dnf install -y centos-release-advanced-virtualization && \
+    dnf install -y --setopt=install_weak_deps=False \
+        libguestfs \
+        libguestfs-devel && \
+    dnf clean -y all
 
-RUN mkdir -p /output \
-    && cd /output \
-    && libguestfs-make-fixed-appliance --xz \
-    && KERNEL_VERSION=$(rpm -qa  kernel-core | sed 's/kernel-core-\(.*\)\.el8.*/\1/') \
-    && LIBGUESTFS_VERSION=$(libguestfs-make-fixed-appliance --version | sed 's/libguestfs-make-fixed-appliance //') \
-    && source /etc/os-release \
-    && mv appliance-${LIBGUESTFS_VERSION}.tar.xz appliance-${LIBGUESTFS_VERSION}-linux-${KERNEL_VERSION}-${ID}${VERSION_ID}.tar.xz \
-    && echo "appliance-${LIBGUESTFS_VERSION}-linux-${KERNEL_VERSION}-${ID}${VERSION_ID}" > latest-version.txt
+RUN mkdir -p /output && \
+    cd /output && \
+    libguestfs-make-fixed-appliance --xz && \
+    KERNEL_VERSION=$(rpm -qa kernel-core | sed 's/kernel-core-\(.*\)\.el8.*/\1/') && \
+    LIBGUESTFS_VERSION=$(libguestfs-make-fixed-appliance --version | sed 's/libguestfs-make-fixed-appliance //') && \
+    source /etc/os-release && \
+    mv appliance-${LIBGUESTFS_VERSION}.tar.xz appliance-${LIBGUESTFS_VERSION}-linux-${KERNEL_VERSION}-${ID}${VERSION_ID}.tar.xz && \
+    echo "appliance-${LIBGUESTFS_VERSION}-linux-${KERNEL_VERSION}-${ID}${VERSION_ID}" > latest-version.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
 ENV LIBGUESTFS_BACKEND direct
 
-# Install centos-release-advanced-virtualization to get the Advanced Virtualization package version
 RUN dnf update -y && \
-    dnf install -y centos-release-advanced-virtualization && \
+    dnf install -y dnf-plugins-core && \
+    dnf config-manager --enable crb && \
     dnf install -y --setopt=install_weak_deps=False \
         libguestfs \
         libguestfs-devel && \
@@ -13,7 +13,7 @@ RUN dnf update -y && \
 RUN mkdir -p /output && \
     cd /output && \
     libguestfs-make-fixed-appliance --xz && \
-    KERNEL_VERSION=$(rpm -qa kernel-core | sed 's/kernel-core-\(.*\)\.el8.*/\1/') && \
+    KERNEL_VERSION=$(rpm -qa kernel-core | sed 's/kernel-core-\(.*\)\.el9.*/\1/') && \
     LIBGUESTFS_VERSION=$(libguestfs-make-fixed-appliance --version | sed 's/libguestfs-make-fixed-appliance //') && \
     source /etc/os-release && \
     mv appliance-${LIBGUESTFS_VERSION}.tar.xz appliance-${LIBGUESTFS_VERSION}-linux-${KERNEL_VERSION}-${ID}${VERSION_ID}.tar.xz && \


### PR DESCRIPTION
As part of https://github.com/kubevirt/kubevirt/pull/8404 we'll want to start using CentOS Stream 9 for the libguestfs appliance along with everything else.

We'll need to coordinate the switch: once the KubeVirt PR is in good shape CI-wise, we should merge this PR and get a fresh appliance built and published as a result; I'll then add a commit switching to the new appliance to the KubeVirt PR, and make sure everything is tested together before going ahead with the change.