### PR TITLE
Add NTFS support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV LIBGUESTFS_BACKEND direct
 RUN dnf update -y && \
     dnf install -y --setopt=install_weak_deps=False \
         libguestfs \
+        libguestfs-winsupport \
         qemu-img && \
     dnf clean -y all
 


### PR DESCRIPTION
To be able to access disks originating from Windows, NTFS support is necessary.