### PR TITLE
add s390x support to the libguestfs-appliance.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM quay.io/centos/centos:stream9
+ARG BUILD_ARCH
+FROM --platform=linux/${BUILD_ARCH} quay.io/centos/centos:stream9
 
 ENV LIBGUESTFS_BACKEND direct
 
@@ -21,7 +22,7 @@ COPY BUILD /appliance/BUILD
 RUN KERNEL_VERSION=$(rpm -qa kernel-core | sed 's/kernel-core-\(.*\)\.el9.*/\1/') && \
     LIBGUESTFS_VERSION=$(libguestfs-make-fixed-appliance --version | sed 's/libguestfs-make-fixed-appliance //') && \
     source /etc/os-release && \
-    APPLIANCE_NAME=libguestfs-appliance-${LIBGUESTFS_VERSION}-qcow2-linux-${KERNEL_VERSION}-${ID}${VERSION_ID}.tar.xz && \
+    APPLIANCE_NAME=libguestfs-appliance-${LIBGUESTFS_VERSION}-qcow2-linux-${KERNEL_VERSION}-${ID}${VERSION_ID}${BUILD_ARCH}.tar.xz && \
     cd /output && \
     tar -cJvf ${APPLIANCE_NAME} /appliance && \
     echo ${APPLIANCE_NAME} > latest-version.txt

--- a/create-libguestfs-appliance.sh
+++ b/create-libguestfs-appliance.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -xe
 
+ARCHS="amd64 s390x"
 IMAGE=${IMAGE:-libguestfs-appliance}
 CONT_NAME=extract-libguestfs-appliance
 # Select an available container runtime
@@ -16,8 +17,9 @@ if [ -z ${RUNTIME} ]; then
     fi
 fi
 
-
-${RUNTIME} build --rm -t ${IMAGE}  .
-${RUNTIME} create --name ${CONT_NAME} ${IMAGE} sh
-${RUNTIME} cp ${CONT_NAME}:/output .
-${RUNTIME} rm ${CONT_NAME}
+for arch in $ARCHS; do 
+    ${RUNTIME} build --build-arg BUILD_ARCH="${arch}" --platform "linux/${arch}" --rm -t ${IMAGE}  .
+    ${RUNTIME} create --name ${CONT_NAME} ${IMAGE} sh
+    ${RUNTIME} cp ${CONT_NAME}:/output .
+    ${RUNTIME} rm ${CONT_NAME}
+done


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds the s390x support to the libguestfs-appliance
This will help us to enable the s390x support for the kubevirt libguestfs-tools image for the s390x E2E Tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
    None

```
