### PR TITLE
fix: libguestfs-appliance tar file not getting created based on the Archs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 ARG BUILD_ARCH
 FROM --platform=linux/${BUILD_ARCH} quay.io/centos/centos:stream9
 
+ARG BUILD_ARCH
+
 ENV LIBGUESTFS_BACKEND direct
+ENV BUILD_ARCH=${BUILD_ARCH}
 
 RUN dnf update -y && \
     dnf install -y --setopt=install_weak_deps=False \
@@ -22,7 +25,7 @@ COPY BUILD /appliance/BUILD
 RUN KERNEL_VERSION=$(rpm -qa kernel-core | sed 's/kernel-core-\(.*\)\.el9.*/\1/') && \
     LIBGUESTFS_VERSION=$(libguestfs-make-fixed-appliance --version | sed 's/libguestfs-make-fixed-appliance //') && \
     source /etc/os-release && \
-    APPLIANCE_NAME=libguestfs-appliance-${LIBGUESTFS_VERSION}-qcow2-linux-${KERNEL_VERSION}-${ID}${VERSION_ID}${BUILD_ARCH}.tar.xz && \
+    APPLIANCE_NAME=libguestfs-appliance-${LIBGUESTFS_VERSION}-qcow2-linux-${KERNEL_VERSION}-${ID}${VERSION_ID}-${BUILD_ARCH}.tar.xz && \
     cd /output && \
     tar -cJvf ${APPLIANCE_NAME} /appliance && \
-    echo ${APPLIANCE_NAME} > latest-version.txt
+    echo ${APPLIANCE_NAME} > latest-version-${BUILD_ARCH}.txt

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # libguestfs-appliance
 This repository contains the setup to build the fixed appliance for libguestfs. A new appliance is built and published weekly at https://storage.googleapis.com/kubevirt-prow/devel/release/kubevirt.
 
-The CI setup that publishes the appliance can be found in the [project-infra](https://github.com/kubevirt/project-infra/tree/master/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance) and weekly job status in [prow](https://prow.ci.kubevirt.io/?type=periodic&job=periodic-libguestfs-appliance-push-weekly-build-main). The latest version of the published appliance can be found by querying: `curl -L https://storage.googleapis.com/kubevirt-prow/devel/release/kubevirt/libguestfs-appliance/latest-version.txt`.
+The CI setup that publishes the appliance can be found in the [project-infra](https://github.com/kubevirt/project-infra/tree/master/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance) and weekly job status in [prow](https://prow.ci.kubevirt.io/?type=periodic&job=periodic-libguestfs-appliance-push-weekly-build-main). The latest version of the published appliance can be found by querying: 
+`curl -L https://storage.googleapis.com/kubevirt-prow/devel/release/kubevirt/libguestfs-appliance/latest-version-amd64.txt`(amd64), 
+`curl -L https://storage.googleapis.com/kubevirt-prow/devel/release/kubevirt/libguestfs-appliance/latest-version-s390x.txt`(s390x)
+.
 
 The main goal of this fixed appliance is to be able to correctly build a container image with libguestfs-tools using bazel. The appliance can be fetched during building time by adding it to the WORKSPACE.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
  This PR added the s390x support for the libguestfs-appliance https://github.com/kubevirt/libguestfs-appliance/pull/18. But there is a small issue in generating the tar files for the both amd64 and s390x archs.

  The BUILD_ARCH is getting populated as empty and the tar file is not getting generated based on archs.
  Due to this we are missing amd64 libguestfs-appliance.
  the BUILD_ARCH is replaced with TARGETARCH this will give the value based on the architecture we target
  during the docker/podman build.

This is the prow job which  recently ran that pushes the libguestfs-appliance to the google cloud storage.
https://storage.googleapis.com/kubevirt-prow/logs/periodic-libguestfs-appliance-push-weekly-build-main/1904572817395945472/build-log.txt

Which shows only one tar file getting copied to gs
`Copying file://./output/libguestfs-appliance-1.54.0-qcow2-linux-5.14.0-573-centos9.tar.xz [Content-Type=application/x-tar]...`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
     None.

```
